### PR TITLE
fix TypeError: 'MongoModel' object is not callable

### DIFF
--- a/mongosql/model.py
+++ b/mongosql/model.py
@@ -18,7 +18,7 @@ class MongoModel(object):
         :rtype: MongoModel
         """
         try:
-            return model.mongomodel()
+            return model.mongomodel
         except AttributeError:
             model.mongomodel = MongoModel(model)
             return model.mongomodel


### PR DESCRIPTION
see https://github.com/kolypto/py-mongosql/issues/1 for details.
